### PR TITLE
Fix coverage report to actually include jekyll-assets

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---require ./lib/jekyll-assets --color --format documentation
+--color --format documentation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
 
 SimpleCov.start
 
+require_relative "../lib/jekyll-assets"
+
 require "jekyll"
 require "liquid"
 require "sprockets"


### PR DESCRIPTION
To get coverage on jekyll-assets, they need to be required after SimpleCov.start is called.